### PR TITLE
fix malformed items when handling oneof or anyof in arrays

### DIFF
--- a/src/swagger2json/array.js
+++ b/src/swagger2json/array.js
@@ -10,8 +10,18 @@ module.exports = function() {
     if (!swagger.items){
     	require('../utils/error.js')('There is a array without items');
     }
-    if(swagger.items.oneOf) delete swagger.items.oneOf;
-    if(swagger.items.anyOf) delete swagger.items.anyOf;
+
+    if ((swagger.items.oneOf || swagger.items.anyOf) && !swagger.items.type && !swagger.items.properties) {
+      const variants = swagger.items.oneOf || swagger.items.anyOf;
+
+      if (Array.isArray(variants) && variants.length > 0) {
+        Object.assign(swagger.items, structuredClone(variants[0]));
+      }
+
+      delete swagger.items.oneOf;
+      delete swagger.items.anyOf;
+    }
+
     if (!swagger.items.properties){
       swagger.items.properties = _.cloneDeep(swagger.items);
     }

--- a/test/generator-body.js
+++ b/test/generator-body.js
@@ -3,7 +3,13 @@
 const assert = require('assert');
 
 describe('generator-body', () => {
-  
+
+  before(() => {
+    globalThis.configurationFile = {
+      minimal_endpoints: false
+    };
+  });
+
   it('good', () => {
 
     const endpoint = require('../seeds/generatorBodyInitial.json')


### PR DESCRIPTION
Fix malformed items error in openapi2postman by normalizing oneOf or anyOf schemas

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

